### PR TITLE
Add dune promote rules, output version first

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -7,17 +7,20 @@
 
 (include_subdirs unqualified)
 
-; (rule
-; (targets sarif_v_2_1_0_t.ml sarif_v_2_1_0_t.mli)
-; (deps    sarif_v_2_1_0.atd)
-; (action  (run atdgen -t %{deps})))
+(rule
+ (targets sarif_v_2_1_0_t.ml sarif_v_2_1_0_t.mli)
+ (deps    sarif_v_2_1_0.atd)
+ (mode (promote (until-clean)))
+ (action  (run atdgen -t %{deps})))
 
-; (rule
-; (targets sarif_v_2_1_0_j.ml sarif_v_2_1_0_j.mli)
-; (deps    sarif_v_2_1_0.atd)
-; (action  (run atdgen -j -j-std %{deps})))
+(rule
+ (targets sarif_v_2_1_0_j.ml sarif_v_2_1_0_j.mli)
+ (deps    sarif_v_2_1_0.atd)
+ (mode (promote (until-clean)))
+ (action  (run atdgen -j -j-std %{deps})))
 
-; (rule
-; (targets sarif_v_2_1_0_v.ml sarif_v_2_1_0_v.mli)
-; (deps    sarif_v_2_1_0.atd)
-; (action  (run atdgen -v %{deps})))
+(rule
+ (targets sarif_v_2_1_0_v.ml sarif_v_2_1_0_v.mli)
+ (deps    sarif_v_2_1_0.atd)
+ (mode (promote (until-clean)))
+ (action  (run atdgen -v %{deps})))

--- a/lib/sarif_v_2_1_0.atd
+++ b/lib/sarif_v_2_1_0.atd
@@ -1497,6 +1497,9 @@ type suppression_status <ocaml attr="deriving show,eq,ord"> = [
   <doc text="A string that indicates the review status of the suppression.">
 
 type sarif_json_schema <ocaml attr="deriving show,eq,ord"> = {
+  version
+    <doc text="The SARIF format version of this log file.">
+    : sarif_version;
   ?inline_external_properties
     <json name="inlineExternalProperties">
     <doc text="References to external property files that share data between runs.">
@@ -1511,9 +1514,6 @@ type sarif_json_schema <ocaml attr="deriving show,eq,ord"> = {
     <json name="$schema">
     <doc text="The URI of the JSON schema corresponding to the version.">
     : string option;
-  version
-    <doc text="The SARIF format version of this log file.">
-    : sarif_version;
 }
   <ocaml valid="Sarif_v_2_1_0_util.validate_sarif_json_schema">
   <doc text="Core type: Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.">

--- a/lib/sarif_v_2_1_0_j.mli
+++ b/lib/sarif_v_2_1_0_j.mli
@@ -2052,6 +2052,7 @@ type run = Sarif_v_2_1_0_t.run = {
   Schema: a standard format for the output of static analysis tools.
 *)
 type sarif_json_schema = Sarif_v_2_1_0_t.sarif_json_schema = {
+  version: sarif_version (** The SARIF format version of this log file. *);
   inline_external_properties: external_properties list option
     (**
       References to external property files that share data between runs.
@@ -2062,8 +2063,7 @@ type sarif_json_schema = Sarif_v_2_1_0_t.sarif_json_schema = {
     *);
   runs: run list (** The set of runs contained in this log file. *);
   schema: string option
-    (** The URI of the JSON schema corresponding to the version. *);
-  version: sarif_version (** The SARIF format version of this log file. *)
+    (** The URI of the JSON schema corresponding to the version. *)
 }
   [@@deriving show,eq,ord]
 

--- a/lib/sarif_v_2_1_0_t.ml
+++ b/lib/sarif_v_2_1_0_t.ml
@@ -2048,6 +2048,7 @@ type run = {
   Schema: a standard format for the output of static analysis tools.
 *)
 type sarif_json_schema = {
+  version: sarif_version (** The SARIF format version of this log file. *);
   inline_external_properties: external_properties list option
     (**
       References to external property files that share data between runs.
@@ -2058,7 +2059,6 @@ type sarif_json_schema = {
     *);
   runs: run list (** The set of runs contained in this log file. *);
   schema: string option
-    (** The URI of the JSON schema corresponding to the version. *);
-  version: sarif_version (** The SARIF format version of this log file. *)
+    (** The URI of the JSON schema corresponding to the version. *)
 }
   [@@deriving show,eq,ord]

--- a/lib/sarif_v_2_1_0_t.mli
+++ b/lib/sarif_v_2_1_0_t.mli
@@ -2048,6 +2048,7 @@ type run = {
   Schema: a standard format for the output of static analysis tools.
 *)
 type sarif_json_schema = {
+  version: sarif_version (** The SARIF format version of this log file. *);
   inline_external_properties: external_properties list option
     (**
       References to external property files that share data between runs.
@@ -2058,7 +2059,6 @@ type sarif_json_schema = {
     *);
   runs: run list (** The set of runs contained in this log file. *);
   schema: string option
-    (** The URI of the JSON schema corresponding to the version. *);
-  version: sarif_version (** The SARIF format version of this log file. *)
+    (** The URI of the JSON schema corresponding to the version. *)
 }
   [@@deriving show,eq,ord]

--- a/lib/sarif_v_2_1_0_v.ml
+++ b/lib/sarif_v_2_1_0_v.ml
@@ -2052,6 +2052,7 @@ type run = Sarif_v_2_1_0_t.run = {
   Schema: a standard format for the output of static analysis tools.
 *)
 type sarif_json_schema = Sarif_v_2_1_0_t.sarif_json_schema = {
+  version: sarif_version (** The SARIF format version of this log file. *);
   inline_external_properties: external_properties list option
     (**
       References to external property files that share data between runs.
@@ -2062,8 +2063,7 @@ type sarif_json_schema = Sarif_v_2_1_0_t.sarif_json_schema = {
     *);
   runs: run list (** The set of runs contained in this log file. *);
   schema: string option
-    (** The URI of the JSON schema corresponding to the version. *);
-  version: sarif_version (** The SARIF format version of this log file. *)
+    (** The URI of the JSON schema corresponding to the version. *)
 }
   [@@deriving show,eq,ord]
 
@@ -6119,16 +6119,16 @@ let create_run
     web_responses = web_responses;
   }
 let create_sarif_json_schema 
+  ~version
   ?inline_external_properties
   ?properties
   ~runs
   ?schema
-  ~version
   () : sarif_json_schema =
   {
+    version = version;
     inline_external_properties = inline_external_properties;
     properties = properties;
     runs = runs;
     schema = schema;
-    version = version;
   }

--- a/lib/sarif_v_2_1_0_v.mli
+++ b/lib/sarif_v_2_1_0_v.mli
@@ -2052,6 +2052,7 @@ type run = Sarif_v_2_1_0_t.run = {
   Schema: a standard format for the output of static analysis tools.
 *)
 type sarif_json_schema = Sarif_v_2_1_0_t.sarif_json_schema = {
+  version: sarif_version (** The SARIF format version of this log file. *);
   inline_external_properties: external_properties list option
     (**
       References to external property files that share data between runs.
@@ -2062,8 +2063,7 @@ type sarif_json_schema = Sarif_v_2_1_0_t.sarif_json_schema = {
     *);
   runs: run list (** The set of runs contained in this log file. *);
   schema: string option
-    (** The URI of the JSON schema corresponding to the version. *);
-  version: sarif_version (** The SARIF format version of this log file. *)
+    (** The URI of the JSON schema corresponding to the version. *)
 }
   [@@deriving show,eq,ord]
 
@@ -3060,11 +3060,11 @@ val validate_run :
   (** Validate a value of type {!type:run}. *)
 
 val create_sarif_json_schema :
+  version: sarif_version ->
   ?inline_external_properties: external_properties list ->
   ?properties: property_bag ->
   runs: run list ->
   ?schema: string ->
-  version: sarif_version ->
   unit -> sarif_json_schema
   (** Create a record of type {!type:sarif_json_schema}. *)
 

--- a/test/test_sarif.ml
+++ b/test/test_sarif.ml
@@ -136,3 +136,14 @@ let%expect_test "taxonomies" =
   let taxonomies = Sarif_v_2_1_0_j.string_of_tool_component @@ List.hd_exn @@ Option.value_exn parsed_run.taxonomies in
   print_endline taxonomies;
   [%expect {| {"guid":"1A567403-868F-405E-92CF-771A9ECB03A1","name":"Requirement levels","shortDescription":{"text":"This taxonomy classifies rules according to whether their use is required or recommended by company policy."},"taxa":[{"id":"RQL1001","name":"Required"},{"id":"RQL1002","name":"Recommended"}]} |}]
+
+let%expect_test "sarif_json_schema.version" =
+  let sarif_json_schema =
+    Sarif_v_2_1_0_v.create_sarif_json_schema
+      ~version:`TwoDotOneDotZero
+      ~runs:[]
+      ()
+  in
+  let s = Sarif_v_2_1_0_j.string_of_sarif_json_schema sarif_json_schema in
+  print_endline s;
+  [%expect {| {"version":"2.1.0","runs":[]} |}]


### PR DESCRIPTION
This adds build rules to build the OCaml source files from the atd file and promote them to the source directory. This makes it easier to make and commit changes to the atd file and its resulting ocaml files.

Furthermore, the version field in the sarif object is moved to the beginning of the definition. The reason is so tools can determine the version reading less data. This is done by switching the order of the fields in the atd definition. This happens to switch the order around as well although I don't think this is a (strong) guarantee from atdgen and may break in the future.

https://github.com/microsoft/sarif-tutorials/blob/819b0f62f47ecde9a8f24dfc387c41926f5edabe/docs/2-Basics.md?plain=1#L31-L33